### PR TITLE
fix: migration vers actions/deploy-pages pour corriger le conflit de …

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,32 +6,48 @@ on:
       - main
 
 permissions:
-  contents: write  # ✅ Autorise le push sur gh-pages
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install Dependencies
         run: npm install
 
-      - name: Build Project
+      - name: Build
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          user_name: github-actions[bot]       # ✅ Ajout du user
-          user_email: github-actions[bot]@users.noreply.github.com
+          path: './dist'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/changelog.md
+++ b/changelog.md
@@ -171,6 +171,27 @@ Les cards de certifications affichaient un `credentialId` mais aucun lien cliqua
 
 ---
 
+## 2026-05-05 — Correction du déploiement GitHub Pages
+
+### Contexte
+Le déploiement échouait avec l'erreur :
+`HttpError: Deployment request failed due to in progress deployment`
+
+### Cause
+Conflit entre deux mécanismes de déploiement simultanés :
+- Le workflow utilisait `peaceiris/actions-gh-pages@v3` (push sur branche `gh-pages`)
+- GitHub Pages était configuré en mode **"GitHub Actions"** (déclenche `actions/deploy-pages` automatiquement)
+Les deux se déclenchaient en parallèle sur chaque push sur `main`.
+
+### Changements
+- **Modifié** : `.github/workflows/deploy.yml` — migration vers `actions/deploy-pages@v5` (méthode officielle)
+  - Ajout `concurrency: group: "pages"` pour bloquer les déploiements simultanés
+  - Permissions correctes : `pages: write` + `id-token: write`
+  - Actions mises à jour : `checkout@v4`, `setup-node@v4` (Node 20), `configure-pages@v5`, `upload-pages-artifact@v3`
+  - Suppression de `peaceiris/actions-gh-pages@v3`
+
+---
+
 ## Format pour les entrées futures
 
 ```markdown


### PR DESCRIPTION
…déploiement GitHub Pages

Remplace peaceiris/actions-gh-pages@v3 par la méthode officielle actions/deploy-pages@v5 avec concurrency group "pages" pour empêcher les déploiements simultanés.