### PR TITLE
fix(deps): migration emailjs-com → @emailjs/browser + lien vérificati…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -97,9 +97,9 @@ Voir `features.md` — section "Fonctionnalités existantes".
 | # | Problème | Composant |
 |---|---|---|
 | 1 | Projets fictifs (placeholder) | `Work.tsx` |
-| ~~2~~ | ~~Liens Credly invalides~~ — **Résolu** | `Certifications.tsx` |
+| ~~2~~ | ~~Liens de vérification invalides~~ — **Résolu** | `Certifications.tsx` |
 | 3 | Bouton "Get In Touch" non relié à `#contact` | `Hero.tsx` |
-| 4 | `emailjs-com` déprécié (remplacer par `@emailjs/browser`) | `Contact.tsx` |
+| ~~4~~ | ~~`emailjs-com` déprécié~~ — **Résolu** | `Contact.tsx` |
 | 5 | CV uniquement en français | `FloatingDownload.tsx`, `Header.tsx` |
 | 6 | i18n incomplète (Experience, Certifications, Work, Contact non traduits) | Multiples |
 | 7 | Pas de sélecteur de langue dans l'UI | `Header.tsx` |
@@ -189,6 +189,27 @@ Les deux se déclenchaient en parallèle sur chaque push sur `main`.
   - Permissions correctes : `pages: write` + `id-token: write`
   - Actions mises à jour : `checkout@v4`, `setup-node@v4` (Node 20), `configure-pages@v5`, `upload-pages-artifact@v3`
   - Suppression de `peaceiris/actions-gh-pages@v3`
+
+---
+
+## 2026-05-05 — Migration emailjs-com → @emailjs/browser + lien DP-203
+
+### Contexte
+- `emailjs-com@3.2.0` était déprécié et absent du `package-lock.json` résolu, causant des échecs intermittents sur CI.
+- L'URL de vérification DP-203 (Microsoft Learn) a été fournie.
+
+### Changements
+- **Modifié** : `package.json` + `package-lock.json` — `emailjs-com` remplacé par `@emailjs/browser`
+- **Modifié** : `src/components/Contact.tsx` — import `@emailjs/browser` (API identique, aucune autre modification nécessaire)
+- **Modifié** : `vite.config.ts` — suppression du bloc `optimizeDeps: { include: ["emailjs-com"] }` devenu inutile
+- **Modifié** : `src/components/Certifications.tsx` — `credentialUrl` DP-203 renseigné (Microsoft Learn)
+
+### Build
+`✓ built in 5.33s` — aucune régression.
+
+### Impact sur la dette technique
+- Résolu : dette #4 (`emailjs-com` déprécié)
+- Résolu : dette #2 DP-203 — lien de vérification désormais complet (Microsoft Learn au lieu de Credly)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -56,8 +57,7 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
-        "zod": "^3.23.8",
-        "emailjs-com": "^3.2.0"
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -151,6 +151,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -59,8 +60,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8",
-    "emailjs-com": "^3.2.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/Certifications.tsx
+++ b/src/components/Certifications.tsx
@@ -11,7 +11,7 @@ const Certifications = () => {
       issuer: "Microsoft",
       date: "2024",
       credentialId: "DP-203",
-      credentialUrl: null as string | null,
+      credentialUrl: "https://learn.microsoft.com/api/credentials/share/fr-fr/metinhoue/4940F1DC6288C3C8?sharingId=D60DF056DF7B1866",
       description: "Demonstrated expertise in integrating, transforming, and consolidating data from various structured and unstructured data systems into structures suitable for building analytics solutions.",
       skills: ["Azure Data Factory", "Azure Synapse Analytics", "Azure Databricks", "Azure Storage"]
     },

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -8,7 +8,7 @@ import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import emailjs from "emailjs-com";
+import emailjs from "@emailjs/browser";
 
 // ✅ EmailJS Configuration (Replace with your actual IDs)
 const SERVICE_ID = "service_t6so8r5"; // Remplace par ton Service ID EmailJS

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,13 +17,7 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-   optimizeDeps: {
-    include: ["emailjs-com"], // ✅ Ajouté pour forcer Vite à inclure emailjs-com
-  },
   build: {
-    rollupOptions: {
-      // Evite les erreurs si emailjs-com fait référence à des libs Node
-      external: [],
-    },
+    rollupOptions: {},
   },
 }));


### PR DESCRIPTION
…on DP-203

Remplace le package déprécié emailjs-com par @emailjs/browser (API identique). Supprime optimizeDeps emailjs-com de vite.config.ts. Ajoute le lien Microsoft Learn pour la certification DP-203.